### PR TITLE
Images sources need to be fixed 🔧️

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 <p align="center"> <img src="https://komarev.com/ghpvc/?username=limaluizpaulo" alt="limaluizpaulo" /> </p>
 
 <p align="center">
-  <img src="https://www.vectorlogo.zone/logos/git-scm/git-scm-icon.svg" alt="git" width="40" height="40"/>
-  <img src="https://devicons.github.io/devicon/devicon.git/icons/html5/html5-original-wordmark.svg" alt="html5" width="40" height="40"/>
-   <img src="https://devicon.dev/devicon.git/icons/css3/css3-original-wordmark.svg" alt="css3" width="40" height="40"/>
-  <img src="https://devicons.github.io/devicon/devicon.git/icons/javascript/javascript-original.svg" alt="javascript" width="40" height="40"/>
-  <img src="https://devicons.github.io/devicon/devicon.git/icons/nodejs/nodejs-original-wordmark.svg" alt="nodejs" width="40" height="40"/>
-  <img src="https://devicons.github.io/devicon/devicon.git/icons/react/react-original-wordmark.svg" alt="react" width="40" height="40"/>
-  <img src="https://devicons.github.io/devicon/devicon.git/icons/typescript/typescript-original.svg" alt="typescript" width="40" height="40"/>
-  <img src="https://devicon.dev/devicon.git/icons/github/github-original-wordmark.svg" alt="github" width="40" height="40"/>
+  <img src="https://www.vectorlogo.zone/logos/git-scm/git-scm-icon.svg" alt="git" height="40"/>
+  <img src="https://ik.imagekit.io/joaonasc/GitHub/assets/tech-logos/html5_uTMKXvufNb.png" alt="html5" height="40"/>
+  <img src="https://ik.imagekit.io/joaonasc/GitHub/assets/tech-logos/css3_VgbzSiOrr7.png" alt="css3" height="40"/>
+  <img src="https://ik.imagekit.io/joaonasc/GitHub/assets/tech-logos/javascript_FxaldcpSw.png" alt="javascript" height="40"/>
+  <img src="https://ik.imagekit.io/joaonasc/GitHub/assets/tech-logos/nodejs_Y2TSm6B_DN.png" alt="nodejs" height="40"/>
+  <img src="https://ik.imagekit.io/joaonasc/GitHub/assets/tech-logos/reactjs_j5WbdQuuJ.png" alt="react" height="40"/>
+  <img src="https://ik.imagekit.io/joaonasc/GitHub/assets/tech-logos/typescript_jx2QG0P-U0.png" alt="typescript" height="40"/>
+  <img src="https://ik.imagekit.io/joaonasc/GitHub/assets/tech-logos/github_CEhhSRJdrr.png" alt="github" height="40"/>
 </p>
 <p><img align="center" src="https://github-readme-stats.vercel.app/api/top-langs/?username=limaluizpaulo&layout=compact&hide=html" alt="limaluizpaulo" /></p>
 


### PR DESCRIPTION
## The sources for the technologies logos are broken

### This pull request is about to fix them by replacing its sources with other sources

- **From where?** I hosted them at my [imagekit.io](https://imagekit.io) account.
- **Why them?** I used the logo style of Git (which is actually up) as a base for searching the others logos.
- **Will you keep the sources for how long?** I'll be using these logos as assets. So, while they are useful, I'll keep them hosted on my account. Anyway, these images don't consume a lot of storage, so I don't think about removing/replacing them.
- **Any changes?** I needed to remove the fixed width of the images elements to get a better fit. Fixed width and height were distorting the images causing bad style.